### PR TITLE
Fix mongod mongos which might need to bind.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,11 +21,13 @@ apps:
     command: mongod
     plugs:
       - network
+      - network-bind
       
   mongos:
     command: mongos
     plugs:
       - network
+      - network-bind
 
   mongo:
     command: mongo


### PR DESCRIPTION
If using the juju-db snap in unit testing, it needs to be able to run mongod command. It can't bind at the moment.