### PR TITLE
Prefix binary paths with bin/

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,40 +18,40 @@ apps:
       - network-bind
 
   mongod:
-    command: mongod
+    command: bin/mongod
     plugs:
       - network
       - network-bind
       
   mongos:
-    command: mongos
+    command: bin/mongos
     plugs:
       - network
       - network-bind
 
   mongo:
-    command: mongo
+    command: bin/mongo
     plugs:
       - network
 
   # Tools
   mongodump:
-    command: mongodump
+    command: bin/mongodump
     plugs:
       - network
 
   mongorestore:
-    command: mongorestore
+    command: bin/mongorestore
     plugs:
       - network
 
   mongostat:
-    command: mongostat
+    command: bin/mongostat
     plugs:
       - network
 
   mongotop:
-    command: mongotop
+    command: bin/mongotop
     plugs:
       - network
 


### PR DESCRIPTION
snapcraft now needs paths relative to root, ie bin/foo