### PR TITLE
Remove mongos from the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,12 +23,6 @@ apps:
       - network
       - network-bind
       
-  mongos:
-    command: bin/mongos
-    plugs:
-      - network
-      - network-bind
-
   mongo:
     command: bin/mongo
     plugs:
@@ -165,7 +159,7 @@ parts:
       export SCONSFLAGS
       export DESTDIR=$SNAPCRAFT_PART_INSTALL
 
-      python3 buildscripts/scons.py install-core $ccflags_arg
+      python3 buildscripts/scons.py install-mongo install-mongod $ccflags_arg
 
       # Strip binaries down to a usable size.
       for file in $SNAPCRAFT_PART_BUILD/build/install/bin/mongo*;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 confinement: strict
 grade: stable
 base: core20
-license: AGPL-3.0
+license: SSPL-1.0
 
 apps:
   daemon:


### PR DESCRIPTION
The binary sizes for mongo have increased a lot. Remove mongos as we don't use it right now.
Also, update the licence to SSPL.