### PR TITLE
Revert to AGPL licence

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 confinement: strict
 grade: stable
 base: core20
-license: SSPL-1.0
+license: AGPL-3.0
 
 apps:
   daemon:


### PR DESCRIPTION
SSPL-1.0 doesn't seem to be supported yet so revert to AGPL-3.0