### PR TITLE
Avoid using libboost dev packages for staging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,10 +99,10 @@ parts:
       - libyaml-cpp0.6
       - libpcre3
       - libpcrecpp0v5
-      - libboost-system-dev
-      - libboost-iostreams-dev
-      - libboost-filesystem-dev
-      - libboost-program-options-dev
+      - libboost-system1.71.0
+      - libboost-iostreams1.71.0
+      - libboost-filesystem1.71.0
+      - libboost-program-options1.71.0
       - libgoogle-perftools4
     build-packages:
       # isn't available on s390x, only needed on the rest anyway.


### PR DESCRIPTION
Fix libboost staging packages to make snap smaller.