### PR TITLE
Build mongo-tools first

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,6 +92,7 @@ parts:
       done
 
   mongo:
+    after: [mongo-tools]
     source: https://github.com/mongodb/mongo
     source-type: git
     source-tag: "r4.4.3"


### PR DESCRIPTION
The arm builders on launchpad are slooooooow. Building mongo takes up to 7 hours and this causes the proxy auth to timeout. So we can't fetch the code to build mongo-tools.
Ensure the we build mongo-tools first.