### PR TITLE
Ensure dependencies are downloaded to pkg cache

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       sed -r -i "s/replace ([^\s]*) ([0-9a-f]*?) => (.*)/replace \1 => \3/" ./go.mod
       rm -rf vendor
       . ./set_goenv.sh
+      go mod download
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin/
       mongo_tools="mongodump mongorestore mongotop mongostat"
       for tool in ${mongo_tools}; do


### PR DESCRIPTION
Latest mongo tools source was missing some cached packages.