### PR TITLE
We need observe interfaces on the snap to prevent apparmor errors

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju-db
-version: '5.0.1'
+version: '5.0.3'
 summary: MongoDB object/document oriented database used internally by Juju.
 description: |
   MongoDB object/document oriented database used internally by Juju.
@@ -16,12 +16,16 @@ apps:
     daemon: simple
     plugs:
       - network-bind
+      - network-observe
+      - system-observe
 
   mongod:
     command: bin/mongod
     plugs:
       - network
       - network-bind
+      - network-observe
+      - system-observe
 
   mongo:
     command: bin/mongo
@@ -57,7 +61,7 @@ parts:
   mongo-tools:
     source: https://github.com/mongodb/mongo-tools
     source-type: git
-    source-tag: "100.4.0"
+    source-tag: "100.5.0"
     plugin: go
     build-packages:
       - pkg-config
@@ -86,7 +90,7 @@ parts:
     after: [mongo-tools]
     source: https://github.com/mongodb/mongo
     source-type: git
-    source-tag: "r5.0.1"
+    source-tag: "r5.0.3"
     plugin: nil
     stage-packages:
       - libssl1.1


### PR DESCRIPTION
Adding the system and network observe interfaces is needed to prevent apparmor log spam.