### PR TITLE
mongo-tools now uses go.mod

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,15 +77,6 @@ parts:
     override-build: |
       export GOROOT=/snap/go/current
       export GOPATH=$(realpath ..)
-      # core20 go plugin only supports go.mod.
-      # mongo-tools uses go dep so convert to go.mod first.
-      # Clean checkout won't have go.mod but interrupted builds will.
-      rm -rf go.mod go.sum
-      go mod init github.com/mongodb/mongo-tools
-      # Remove a bogus replace with a non-existent revision.
-      sed -r -i "s/replace ([^\s]*) ([0-9a-f]*?) => (.*)/replace \1 => \3/" ./go.mod
-      rm -rf vendor
-      go mod download
       ./make build
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin/
       mongo_tools="mongodump mongorestore mongotop mongostat"


### PR DESCRIPTION
mongo-tools has been updated to use go.mod properly so delete the workaround in snapcraft.