### PR TITLE
s390x and ppc64 need python3 to be installed for building

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,6 +113,8 @@ parts:
       - libssl-dev
       - libcurl4-openssl-dev
       # python packages cribbed from deb, might need changed.
+      - python3
+      - python3-dev
       - python-typing
       - python3-cheetah
       - python3-pip


### PR DESCRIPTION
Add python3 to build stage as it's needed by s390x and ppc64 builds