### PR TITLE
Add lzma-dev lib which is needed on arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,6 +113,7 @@ parts:
       - try:
           - libgoogle-perftools-dev
       - libssl-dev
+      - liblzma-dev
       - libcurl4-openssl-dev
       # python packages cribbed from deb, might need changed.
       - python-typing


### PR DESCRIPTION
Fix arm64 builds by adding lzma-dev library.