### PR TITLE
[JUJU-2533] Allow mongo dump and restore home access

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,11 +39,13 @@ apps:
     command: bin/mongodump
     plugs:
       - network
+      - home
 
   mongorestore:
     command: bin/mongorestore
     plugs:
       - network
+      - home
 
   mongostat:
     command: bin/mongostat


### PR DESCRIPTION
The following adds the home[1] interface to the mongo dump and restore commands. This should allow access to the $HOME directory.

The documentation is really easy to following, so the change is simple. This only targets 4.4 and will be pushed to subsequent branches.

  1. https://snapcraft.io/docs/home-interface