### PR TITLE
Add logrotate to snap

### DIFF
--- a/logrotate/juju-db.conf
+++ b/logrotate/juju-db.conf
@@ -1,0 +1,10 @@
+/var/snap/juju-db/common/logs/mongodb.log {
+    weekly
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+    copytruncate
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,12 @@ apps:
       - system-observe
       - mount-observe
 
+  logrotate:
+    command: usr/sbin/logrotate --verbose --state $SNAP_COMMON/logrotate.state $SNAP/etc/logrotate-juju-db.conf
+    daemon: simple
+    restart-condition: on-failure
+    timer: 00:00
+
   mongod:
     command: bin/mongod
     plugs:
@@ -62,6 +68,7 @@ parts:
     plugin: dump
     source: snap/local/
     source-type: local
+
   mongo-tools:
     source: https://github.com/mongodb/mongo-tools
     source-type: git
@@ -173,3 +180,11 @@ parts:
           do strip -s $file;
       done
       mv $SNAPCRAFT_PART_BUILD/build/install/bin $SNAPCRAFT_PART_INSTALL/
+
+  logrotate:
+    plugin: dump
+    source: logrotate
+    stage-packages:
+      - logrotate
+    organize:
+      juju-db.conf: etc/logrotate-juju-db.conf


### PR DESCRIPTION
This changes adds the logrotate service to the snap so that mongodb log
files are properly rotated. This is particularly useful on longer
running controller units, see LP 1997192 [1], to prevent the disk to run
out of space because of old and potentially large log files.

[1] https://bugs.launchpad.net/juju/+bug/1997192

Closes: https://bugs.launchpad.net/juju/+bug/1997192
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
