### PR TITLE
Fix permissions on logrotate conf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -184,7 +184,9 @@ parts:
   logrotate:
     plugin: dump
     source: logrotate
+    source-type: local
     stage-packages:
       - logrotate
-    organize:
-      juju-db.conf: etc/logrotate-juju-db.conf
+    override-build: |
+      snapcraftctl build
+      install --mode 0644 juju-db.conf ${SNAPCRAFT_PART_INSTALL}/etc/logrotate-juju-db.conf


### PR DESCRIPTION
Incorrect permissions on `logrotate` configuration files will cause
`logrotate` to fail with an error.

Instead of using the `organize` feature of the `logrotate` part, which
copies the configuration file with incorrect permissions, use the
`install` utility.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
